### PR TITLE
Feature 11 cleaning up retrieve timetable

### DIFF
--- a/src/main/java/edit_timetable_use_case/AddCourseInteractor.java
+++ b/src/main/java/edit_timetable_use_case/AddCourseInteractor.java
@@ -37,7 +37,9 @@ public class AddCourseInteractor implements AddCourseInputBoundary{
         TimetableCourse course = new TimetableCourse(calCourse.getTitle(), sections, calCourse.getCourseSession(),
                 calCourse.getCourseCode(), calCourse.getBreadth());
         timetable.AddToCourseList(course);
-        RetrieveTimetableInteractor RTInteractor = new RetrieveTimetableInteractor(timetable, session);
+        RetrieveTimetableInteractor RTInteractor = new RetrieveTimetableInteractor();
+        RTInteractor.setSession(session);
+        RTInteractor.setTimetable(timetable);
         TimetableModel updatedTimetable = RTInteractor.retrieveTimetable();
         EditTimetableResponseModel editTimetableResponseModel =
                 new EditTimetableResponseModel(request.getCourseCode(), request.getSectionCodes(), updatedTimetable);

--- a/src/main/java/edit_timetable_use_case/AddCourseInteractor.java
+++ b/src/main/java/edit_timetable_use_case/AddCourseInteractor.java
@@ -1,8 +1,8 @@
 package edit_timetable_use_case;
 
 import entities.*;
-import retrieve_timetable_use_case.RetrieveTimetableInteractor;
-import retrieve_timetable_use_case.TimetableModel;
+import retrieve_timetable_use_case.application_business.RetrieveTimetableInteractor;
+import retrieve_timetable_use_case.application_business.TimetableModel;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/edit_timetable_use_case/EditTimetableResponseModel.java
+++ b/src/main/java/edit_timetable_use_case/EditTimetableResponseModel.java
@@ -1,6 +1,6 @@
 package edit_timetable_use_case;
 
-import retrieve_timetable_use_case.TimetableModel;
+import retrieve_timetable_use_case.application_business.TimetableModel;
 
 import java.util.List;
 
@@ -26,11 +26,6 @@ public class EditTimetableResponseModel {
 
     public String getCourseCode() {
         return courseCode;
-    }
-
-    /*This method is unused, creating an IntelliJ warning. It will be used in the AddCourse use case.*/
-    public List<String> getSectionCodes(){
-        return sectionCodes;
     }
 
 

--- a/src/main/java/edit_timetable_use_case/RemoveCourseInteractor.java
+++ b/src/main/java/edit_timetable_use_case/RemoveCourseInteractor.java
@@ -41,7 +41,9 @@ public class RemoveCourseInteractor implements RemoveCourseInputBoundary {
         }
 
         RetrieveTimetableInteractor
-                RTInteractor = new RetrieveTimetableInteractor(timetable, new Session(""));
+                RTInteractor = new RetrieveTimetableInteractor();
+        RTInteractor.setTimetable(timetable);
+        RTInteractor.setSession(new Session(""));
 
         TimetableModel updatedTimetable = RTInteractor.retrieveTimetable();
         EditTimetableResponseModel editTimetableResponseModel =

--- a/src/main/java/edit_timetable_use_case/RemoveCourseInteractor.java
+++ b/src/main/java/edit_timetable_use_case/RemoveCourseInteractor.java
@@ -2,8 +2,8 @@ package edit_timetable_use_case;
 
 import entities.Session;
 import entities.Timetable;
-import retrieve_timetable_use_case.RetrieveTimetableInteractor;
-import retrieve_timetable_use_case.TimetableModel;
+import retrieve_timetable_use_case.application_business.RetrieveTimetableInteractor;
+import retrieve_timetable_use_case.application_business.TimetableModel;
 
 import java.util.ArrayList;
 

--- a/src/main/java/recommend_br_use_case/RecommendBRInteractor.java
+++ b/src/main/java/recommend_br_use_case/RecommendBRInteractor.java
@@ -1,8 +1,8 @@
 package recommend_br_use_case;
 
 import entities.*;
-import retrieve_timetable_use_case.CourseModel;
-import retrieve_timetable_use_case.EntityConverter;
+import retrieve_timetable_use_case.application_business.CourseModel;
+import retrieve_timetable_use_case.application_business.EntityConverter;
 
 
 import java.util.ArrayList;

--- a/src/main/java/recommend_br_use_case/RecommendBRResponseModel.java
+++ b/src/main/java/recommend_br_use_case/RecommendBRResponseModel.java
@@ -1,6 +1,6 @@
 package recommend_br_use_case;
 
-import retrieve_timetable_use_case.CourseModel;
+import retrieve_timetable_use_case.application_business.CourseModel;
 
 import java.util.List;
 

--- a/src/main/java/retrieve_timetable_use_case/BlockModel.java
+++ b/src/main/java/retrieve_timetable_use_case/BlockModel.java
@@ -1,7 +1,5 @@
 package retrieve_timetable_use_case;
 
-import java.util.Objects;
-
 /**
  * A data carrier class that doubles as a request and resposne model containing all information
  * that a Block would contain while protecting Controllers and Presenters from changes to

--- a/src/main/java/retrieve_timetable_use_case/BlockModel.java
+++ b/src/main/java/retrieve_timetable_use_case/BlockModel.java
@@ -1,11 +1,21 @@
 package retrieve_timetable_use_case;
 
+import java.util.Objects;
+
+/**
+ * A data carrier class that doubles as a request and resposne model containing all information
+ * that a Block would contain while protecting Controllers and Presenters from changes to
+ * the original entity.
+ * Day refers to the day that a given block occurs.
+ * startTime and endTime refer to the start and end-time of a given class/tutorial/practical class.
+ * room refers to the location of the class.
+ */
 public class BlockModel {
 
-    private int day;
-    private double startTime;
-    private double endTime;
-    private String room;
+    private final int day;
+    private final double startTime;
+    private final double endTime;
+    private final String room;
 
     public BlockModel(int day, double startTime, double endTime, String room){
         this.day = day;
@@ -28,5 +38,13 @@ public class BlockModel {
 
     public String getRoom() {
         return room;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BlockModel that = (BlockModel) o;
+        return getDay() == that.getDay() && Double.compare(that.getStartTime(), getStartTime()) == 0 && Double.compare(that.getEndTime(), getEndTime()) == 0 && getRoom().equals(that.getRoom());
     }
 }

--- a/src/main/java/retrieve_timetable_use_case/CourseModel.java
+++ b/src/main/java/retrieve_timetable_use_case/CourseModel.java
@@ -3,9 +3,20 @@ package retrieve_timetable_use_case;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * A data carrier class that doubles as a request and response model containing all information
+ * that a Course would contain while protecting Controllers and Presenters from changes to
+ * the original entity.
+ * It can contain the information of either a CalendarCourse or TimetableCourse as needed.
+ * Title refers to the course's title (e.g. "Introduction to the Theory of Computation").
+ * Sections is a list of SectionModels that correspond to the sections that belong to the course.
+ * courseSession determines which session the course belongs to.
+ * courseCode is an abbreviated code assigned to the course (e.g. CSC108).
+ * breadth refers to the breadth category the course belongs to.
+ */
 public class CourseModel {
     private final String title;
-    private List<SectionModel> sections;
+    private final List<SectionModel> sections;
     private final String courseSession;
     private final String courseCode;
     private final String breadth;
@@ -24,7 +35,7 @@ public class CourseModel {
     }
 
     public List<SectionModel> getSections() {
-        return new ArrayList<SectionModel>(this.sections);
+        return new ArrayList<>(this.sections);
     }
 
     public String getCourseSession() {
@@ -37,5 +48,13 @@ public class CourseModel {
 
     public String getBreadth() {
         return this.breadth;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CourseModel that = (CourseModel) o;
+        return getTitle().equals(that.getTitle()) && getSections().equals(that.getSections()) && getCourseSession().equals(that.getCourseSession()) && getCourseCode().equals(that.getCourseCode()) && getBreadth().equals(that.getBreadth());
     }
 }

--- a/src/main/java/retrieve_timetable_use_case/EntityConverter.java
+++ b/src/main/java/retrieve_timetable_use_case/EntityConverter.java
@@ -8,10 +8,14 @@ import entities.Session;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+/**
+ * A class of static methods to be freely used by different interactors to convert from timetable
+ * and session entities to their corresponding model.
+ */
 public class EntityConverter {
 
     public static SessionModel generateSessionResponse(Session session){
-        HashMap<String, CourseModel> courses = new HashMap<String, CourseModel>();
+        HashMap<String, CourseModel> courses = new HashMap<>();
         for (String courseCode : session.getAllSessionCourses().keySet()){
             courses.put(courseCode, generateCourseResponse(session.getAllSessionCourses().get(courseCode)));
         }
@@ -19,7 +23,7 @@ public class EntityConverter {
     }
 
     public static CourseModel generateCourseResponse(Course course){
-        ArrayList<SectionModel> sections = new ArrayList<SectionModel>();
+        ArrayList<SectionModel> sections = new ArrayList<>();
 
         for (Section section : course.getSections()){
             sections.add(generateSectionResponse(section));
@@ -30,7 +34,7 @@ public class EntityConverter {
     }
 
     public static SectionModel generateSectionResponse(Section section){
-        ArrayList<BlockModel> blocks = new ArrayList<BlockModel>();
+        ArrayList<BlockModel> blocks = new ArrayList<>();
 
         for (Block block : section.getBlocks()){
             blocks.add(generateBlockResponse(block));
@@ -42,5 +46,4 @@ public class EntityConverter {
     public static BlockModel generateBlockResponse(Block block){
         return new BlockModel(block.getDay(), block.getStartTime(), block.getEndTime(), block.getRoom());
     }
-
 }

--- a/src/main/java/retrieve_timetable_use_case/RetrieveTimetableController.java
+++ b/src/main/java/retrieve_timetable_use_case/RetrieveTimetableController.java
@@ -1,5 +1,9 @@
 package retrieve_timetable_use_case;
 
+/**
+ * The controller used in the RetrieveTimetableUseCase.
+ * interactor is the interactor associated with the RetrieveTimetableUseCase.
+ */
 public class RetrieveTimetableController {
 
     RetrieveTimetableInputBoundary interactor;
@@ -8,18 +12,31 @@ public class RetrieveTimetableController {
         this.interactor = interactor;
     }
 
+    /**
+     * @param courseCode The course code of a course in the Session currently loaded in
+     *                   the interactor.
+     * @return a CourseModel containing the course's data.
+     */
     public CourseModel retrieveCalendarCourse(String courseCode){
         RetrieveTimetableRequestModel requestModel =
                 new RetrieveTimetableRequestModel("", courseCode, "");
         return interactor.retrieveCalendarCourse(requestModel);
     }
 
+    /**
+     * @param courseCode The course code of a course in the Timetable currently loaded in
+     *                   the interactor.
+     * @return a CourseModel containing the course's data.
+     */
     public CourseModel retrieveTimetableCourse(String courseCode){
         RetrieveTimetableRequestModel requestModel =
                 new RetrieveTimetableRequestModel("", courseCode, "");
         return interactor.retrieveTimetableCourse(requestModel);
     }
 
+    /**
+     * @return a TimetableModel containing all of the timetable's data.
+     */
     public TimetableModel retrieveTimetable(){
         return interactor.retrieveTimetable();
     }

--- a/src/main/java/retrieve_timetable_use_case/RetrieveTimetableInputBoundary.java
+++ b/src/main/java/retrieve_timetable_use_case/RetrieveTimetableInputBoundary.java
@@ -7,10 +7,10 @@ package retrieve_timetable_use_case;
  */
 public interface RetrieveTimetableInputBoundary {
 
-    public CourseModel retrieveTimetableCourse(RetrieveTimetableRequestModel requestModel);
+    CourseModel retrieveTimetableCourse(RetrieveTimetableRequestModel requestModel);
 
-    public CourseModel retrieveCalendarCourse(RetrieveTimetableRequestModel requestModel);
+    CourseModel retrieveCalendarCourse(RetrieveTimetableRequestModel requestModel);
 
-    public TimetableModel retrieveTimetable();
-    public SessionModel retrieveSession();
+    TimetableModel retrieveTimetable();
+    SessionModel retrieveSession();
 }

--- a/src/main/java/retrieve_timetable_use_case/RetrieveTimetableInputBoundary.java
+++ b/src/main/java/retrieve_timetable_use_case/RetrieveTimetableInputBoundary.java
@@ -1,5 +1,8 @@
 package retrieve_timetable_use_case;
 
+import entities.Session;
+import entities.Timetable;
+
 /**
  * The input boundary used in the RetrieveTimetable use case.
  * All implementations should be able to retrieve the data of the entities below and return the
@@ -7,10 +10,14 @@ package retrieve_timetable_use_case;
  */
 public interface RetrieveTimetableInputBoundary {
 
-    public CourseModel retrieveTimetableCourse(RetrieveTimetableRequestModel requestModel);
+    CourseModel retrieveTimetableCourse(RetrieveTimetableRequestModel requestModel);
 
-    public CourseModel retrieveCalendarCourse(RetrieveTimetableRequestModel requestModel);
+    CourseModel retrieveCalendarCourse(RetrieveTimetableRequestModel requestModel);
 
-    public TimetableModel retrieveTimetable();
-    public SessionModel retrieveSession();
+    TimetableModel retrieveTimetable();
+    SessionModel retrieveSession();
+
+    void setSession(Session session);
+
+    void setTimetable(Timetable timetable);
 }

--- a/src/main/java/retrieve_timetable_use_case/RetrieveTimetableInputBoundary.java
+++ b/src/main/java/retrieve_timetable_use_case/RetrieveTimetableInputBoundary.java
@@ -1,5 +1,10 @@
 package retrieve_timetable_use_case;
 
+/**
+ * The input boundary used in the RetrieveTimetable use case.
+ * All implementations should be able to retrieve the data of the entities below and return the
+ * corresponding model.
+ */
 public interface RetrieveTimetableInputBoundary {
 
     public CourseModel retrieveTimetableCourse(RetrieveTimetableRequestModel requestModel);

--- a/src/main/java/retrieve_timetable_use_case/RetrieveTimetableInteractor.java
+++ b/src/main/java/retrieve_timetable_use_case/RetrieveTimetableInteractor.java
@@ -6,24 +6,29 @@ import entities.Timetable;
 
 import java.util.ArrayList;
 
+/**
+ * The main interactor used in the retrieve timetable use case. It uses EntityConverter's methods
+ * to accept a timetable/session data entity and convert it into the corresponding model, which
+ * can then be used and passed between controllers and presenters as necessary.
+ * timetable refers to the Timetable currently loaded into the interactor, and any retrieveTimetableCourse
+ * calls will search through timetable.
+ * session similarly refers to the Session currently into the interavtor, and retrieveCalendarCourse
+ * calls will search through session.
+ */
 public class RetrieveTimetableInteractor implements RetrieveTimetableInputBoundary {
 
-    private Timetable timetable;
-    private Session session;
+    private final Timetable timetable;
+    private final Session session;
 
     public RetrieveTimetableInteractor(Timetable timetable, Session session){
         this.timetable = timetable;
         this.session = session;
     }
 
-    /**
-     * @param requestModel
-     * @return
-     */
 
     /**
-     * @param requestModel
-     * @return
+     * @param requestModel contains the course code of the desired course in timetable.
+     * @return a CourseModel of the given course containing equivalent information.
      */
     @Override
     public CourseModel retrieveTimetableCourse(RetrieveTimetableRequestModel requestModel) {
@@ -31,22 +36,28 @@ public class RetrieveTimetableInteractor implements RetrieveTimetableInputBounda
     }
 
     /**
-     * @param requestModel
-     * @return
+     * @param requestModel contains the course code of the desired course in session.
+     * @return a CourseModel of the given course containing equivalent information.
      */
     @Override
     public CourseModel retrieveCalendarCourse(RetrieveTimetableRequestModel requestModel) {
         return EntityConverter.generateCourseResponse(session.getCalendarCourse(requestModel.getCourseCode()));
     }
 
+    /**
+     * @return a SessionModel containing all information in session.
+     */
     @Override
     public SessionModel retrieveSession(){
         return EntityConverter.generateSessionResponse(session);
     }
 
+    /**
+     * @return a TimetableModel containing all information in timetable.
+     */
     @Override
     public TimetableModel retrieveTimetable(){
-        ArrayList<CourseModel> courses = new ArrayList<CourseModel>();
+        ArrayList<CourseModel> courses = new ArrayList<>();
         for (Course course : timetable.getCourseList()){
             courses.add(EntityConverter.generateCourseResponse(course));
         }

--- a/src/main/java/retrieve_timetable_use_case/RetrieveTimetableInteractor.java
+++ b/src/main/java/retrieve_timetable_use_case/RetrieveTimetableInteractor.java
@@ -17,8 +17,8 @@ import java.util.ArrayList;
  */
 public class RetrieveTimetableInteractor implements RetrieveTimetableInputBoundary {
 
-    private final Timetable timetable;
-    private final Session session;
+    private Timetable timetable;
+    private Session session;
 
     public RetrieveTimetableInteractor(Timetable timetable, Session session){
         this.timetable = timetable;
@@ -50,6 +50,16 @@ public class RetrieveTimetableInteractor implements RetrieveTimetableInputBounda
     @Override
     public SessionModel retrieveSession(){
         return EntityConverter.generateSessionResponse(session);
+    }
+
+    @Override
+    public void setSession(Session session) {
+        this.session = session;
+    }
+
+    @Override
+    public void setTimetable(Timetable timetable) {
+        this.timetable = timetable;
     }
 
     /**

--- a/src/main/java/retrieve_timetable_use_case/RetrieveTimetableRequestModel.java
+++ b/src/main/java/retrieve_timetable_use_case/RetrieveTimetableRequestModel.java
@@ -1,9 +1,16 @@
 package retrieve_timetable_use_case;
 
+/**
+ * A request model containing all requirements of a given retrieve timetable request.
+ * timetable is used in case one of many timetables needs to be accessed.
+ * courseCode refers to the course that needs to be copied, and is required for retrieveTimetableCourse
+ * and retrieveCalendarCourse calls.
+ * sectionCode is used to retrieve a specific section.
+ */
 public class RetrieveTimetableRequestModel {
-    private String timetable;
-    private String courseCode;
-    private String sectionCode;
+    private final String timetable;
+    private final String courseCode;
+    private final String sectionCode;
 
     public RetrieveTimetableRequestModel(String timetable, String courseCode, String sectionCode){
         this.timetable = timetable;

--- a/src/main/java/retrieve_timetable_use_case/SectionModel.java
+++ b/src/main/java/retrieve_timetable_use_case/SectionModel.java
@@ -2,11 +2,19 @@ package retrieve_timetable_use_case;
 
 import java.util.List;
 
+/**
+ * A data carrier class that doubles as a request and response model containing all information
+ * that a Section would contain while protecting Controllers and Presenters from changes to
+ * the original entity.
+ * code is the section code: (e.g. "LEC0101").
+ * instructor is a string containing the name of the section's instructors.
+ * blocks is a List of BlockModels that contains the corresponding BlockModel of blocks in the section.
+ */
 public class SectionModel {
 
-    private String code;
-    private String instructor;
-    private List<BlockModel> blocks;
+    private final String code;
+    private final String instructor;
+    private final List<BlockModel> blocks;
 
     public SectionModel(String code, String instructor, List<BlockModel> blocks){
         this.code = code;
@@ -24,5 +32,13 @@ public class SectionModel {
 
     public List<BlockModel> getBlocks() {
         return blocks;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SectionModel that = (SectionModel) o;
+        return getCode().equals(that.getCode()) && getInstructor().equals(that.getInstructor()) && getBlocks().equals(that.getBlocks());
     }
 }

--- a/src/main/java/retrieve_timetable_use_case/SessionModel.java
+++ b/src/main/java/retrieve_timetable_use_case/SessionModel.java
@@ -26,4 +26,12 @@ public class SessionModel {
     public String getSessionType() {
         return sessionType;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SessionModel that = (SessionModel) o;
+        return getCourses().equals(that.getCourses()) && getSessionType().equals(that.getSessionType());
+    }
 }

--- a/src/main/java/retrieve_timetable_use_case/SessionModel.java
+++ b/src/main/java/retrieve_timetable_use_case/SessionModel.java
@@ -2,10 +2,17 @@ package retrieve_timetable_use_case;
 
 import java.util.HashMap;
 
+/**
+ *  A data carrier class that doubles as a request and response model containing all information
+ *  that a Session would contain while protecting Controllers and Presenters from changes to
+ *  the original entity.
+ *  courses is a HashMap from course codes to corresponding course models that belong to the session.
+ *  sessionType is a string (e.g. "F") that details the semester the session belongs to.
+ */
 public class SessionModel {
 
-    private HashMap<String, CourseModel> courses;
-    private String sessionType;
+    private final HashMap<String, CourseModel> courses;
+    private final String sessionType;
 
     public SessionModel(HashMap<String, CourseModel> courses, String sessionType){
         this.courses = courses;

--- a/src/main/java/retrieve_timetable_use_case/TimetableModel.java
+++ b/src/main/java/retrieve_timetable_use_case/TimetableModel.java
@@ -2,9 +2,15 @@ package retrieve_timetable_use_case;
 
 import java.util.List;
 
+/**
+ *  A data carrier class that doubles as a request and response model containing all information
+ *  that a Session would contain while protecting Controllers and Presenters from changes to
+ *  the original entity.
+ *  courses is a list of CourseModels that are contained in the timetable.
+ */
 public class TimetableModel {
 
-    private List<CourseModel> courses;
+    private final List<CourseModel> courses;
 
     public TimetableModel(List<CourseModel> courses){
         this.courses = courses;

--- a/src/main/java/retrieve_timetable_use_case/TimetableModel.java
+++ b/src/main/java/retrieve_timetable_use_case/TimetableModel.java
@@ -19,4 +19,12 @@ public class TimetableModel {
     public List<CourseModel> getCourses() {
         return courses;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TimetableModel that = (TimetableModel) o;
+        return getCourses().equals(that.getCourses());
+    }
 }

--- a/src/main/java/retrieve_timetable_use_case/TimetableModelConverter.java
+++ b/src/main/java/retrieve_timetable_use_case/TimetableModelConverter.java
@@ -6,8 +6,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+/**
+ * A class of static methods that converts from session/timetable models to view models.
+ */
 public class TimetableModelConverter {
 
+    /**
+     * @param session A SessionModel object.
+     * @return A SessionViewModel containing equivalent data.
+     */
     public static SessionViewModel sessionToView(SessionModel session){
         HashMap<String, TimetableViewCourseModel> courses = new HashMap<String, TimetableViewCourseModel>();
         for (String courseCode : session.getCourses().keySet()){
@@ -16,6 +23,10 @@ public class TimetableModelConverter {
         return new SessionViewModel(courses, session.getSessionType());
     }
 
+    /**
+     * @param timetable A TimetableModel object.
+     * @return A TimetableViewModel containing equivalent data.
+     */
     public static TimetableViewModel timetableToView(TimetableModel timetable){
         List<TimetableViewCourseModel> courses = new ArrayList<TimetableViewCourseModel>();
         for (CourseModel course : timetable.getCourses() ){
@@ -25,6 +36,10 @@ public class TimetableModelConverter {
         return new TimetableViewModel(courses);
     }
 
+    /**
+     * @param course A CourseModel object.
+     * @return A CourseViewModel containing equivalent data.
+     */
     public static TimetableViewCourseModel courseToView(CourseModel course){
         List<TimetableViewSectionModel> sections = new ArrayList<TimetableViewSectionModel>();
         for (SectionModel section : course.getSections()){
@@ -34,6 +49,10 @@ public class TimetableModelConverter {
         return new TimetableViewCourseModel(course.getCourseCode(), sections);
     }
 
+    /**
+     * @param section A SectionModel object.
+     * @return A SectionViewModel containing equivalent data.
+     */
     public static TimetableViewSectionModel sectionToView(SectionModel section){
         List<TimetableViewBlockModel> blocks = new ArrayList<TimetableViewBlockModel>();
         for (BlockModel block : section.getBlocks()){
@@ -43,6 +62,10 @@ public class TimetableModelConverter {
         return new TimetableViewSectionModel(section.getCode(), blocks);
     }
 
+    /**
+     * @param block A BlockModel object.
+     * @return A BlockViewModel containing equivalent data.
+     */
     public static TimetableViewBlockModel blockToView(BlockModel block){
         return new TimetableViewBlockModel(block.getDay(), block.getStartTime(), block.getEndTime());
     }

--- a/src/main/java/retrieve_timetable_use_case/TimetableModelConverter.java
+++ b/src/main/java/retrieve_timetable_use_case/TimetableModelConverter.java
@@ -16,7 +16,7 @@ public class TimetableModelConverter {
      * @return A SessionViewModel containing equivalent data.
      */
     public static SessionViewModel sessionToView(SessionModel session){
-        HashMap<String, TimetableViewCourseModel> courses = new HashMap<String, TimetableViewCourseModel>();
+        HashMap<String, TimetableViewCourseModel> courses = new HashMap<>();
         for (String courseCode : session.getCourses().keySet()){
             courses.put(courseCode, courseToView(session.getCourses().get(courseCode)));
         }
@@ -28,7 +28,7 @@ public class TimetableModelConverter {
      * @return A TimetableViewModel containing equivalent data.
      */
     public static TimetableViewModel timetableToView(TimetableModel timetable){
-        List<TimetableViewCourseModel> courses = new ArrayList<TimetableViewCourseModel>();
+        List<TimetableViewCourseModel> courses = new ArrayList<>();
         for (CourseModel course : timetable.getCourses() ){
             courses.add(courseToView(course));
         }
@@ -41,7 +41,7 @@ public class TimetableModelConverter {
      * @return A CourseViewModel containing equivalent data.
      */
     public static TimetableViewCourseModel courseToView(CourseModel course){
-        List<TimetableViewSectionModel> sections = new ArrayList<TimetableViewSectionModel>();
+        List<TimetableViewSectionModel> sections = new ArrayList<>();
         for (SectionModel section : course.getSections()){
             sections.add(sectionToView(section));
         }
@@ -54,7 +54,7 @@ public class TimetableModelConverter {
      * @return A SectionViewModel containing equivalent data.
      */
     public static TimetableViewSectionModel sectionToView(SectionModel section){
-        List<TimetableViewBlockModel> blocks = new ArrayList<TimetableViewBlockModel>();
+        List<TimetableViewBlockModel> blocks = new ArrayList<>();
         for (BlockModel block : section.getBlocks()){
             blocks.add(blockToView(block));
         }

--- a/src/main/java/retrieve_timetable_use_case/application_business/BlockModel.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/BlockModel.java
@@ -1,4 +1,4 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.application_business;
 
 /**
  * A data carrier class that doubles as a request and resposne model containing all information

--- a/src/main/java/retrieve_timetable_use_case/application_business/BlockModel.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/BlockModel.java
@@ -1,5 +1,7 @@
 package retrieve_timetable_use_case.application_business;
 
+import java.util.Objects;
+
 /**
  * A data carrier class that doubles as a request and resposne model containing all information
  * that a Block would contain while protecting Controllers and Presenters from changes to
@@ -45,4 +47,10 @@ public class BlockModel {
         BlockModel that = (BlockModel) o;
         return getDay() == that.getDay() && Double.compare(that.getStartTime(), getStartTime()) == 0 && Double.compare(that.getEndTime(), getEndTime()) == 0 && getRoom().equals(that.getRoom());
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(day, startTime, endTime, room);
+    }
+
 }

--- a/src/main/java/retrieve_timetable_use_case/application_business/CourseModel.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/CourseModel.java
@@ -1,4 +1,4 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.application_business;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/retrieve_timetable_use_case/application_business/CourseModel.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/CourseModel.java
@@ -1,6 +1,7 @@
 package retrieve_timetable_use_case.application_business;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -55,6 +56,10 @@ public class CourseModel {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CourseModel that = (CourseModel) o;
-        return getTitle().equals(that.getTitle()) && getSections().equals(that.getSections()) && getCourseSession().equals(that.getCourseSession()) && getCourseCode().equals(that.getCourseCode()) && getBreadth().equals(that.getBreadth());
+        return getTitle().equals(that.getTitle()) &&
+                new HashSet<>(getSections()).equals(new HashSet<>(that.getSections()))
+                && getCourseSession().equals(that.getCourseSession())
+                && getCourseCode().equals(that.getCourseCode())
+                && getBreadth().equals(that.getBreadth());
     }
 }

--- a/src/main/java/retrieve_timetable_use_case/application_business/EntityConverter.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/EntityConverter.java
@@ -1,4 +1,4 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.application_business;
 
 import entities.Block;
 import entities.Course;

--- a/src/main/java/retrieve_timetable_use_case/application_business/EntityConverter.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/EntityConverter.java
@@ -1,9 +1,6 @@
 package retrieve_timetable_use_case.application_business;
 
-import entities.Block;
-import entities.Course;
-import entities.Section;
-import entities.Session;
+import entities.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,5 +42,13 @@ public class EntityConverter {
 
     public static BlockModel generateBlockResponse(Block block){
         return new BlockModel(block.getDay(), block.getStartTime(), block.getEndTime(), block.getRoom());
+    }
+
+    public static TimetableModel generateTimetableResponse(Timetable timetable){
+        ArrayList<CourseModel> courses = new ArrayList<>();
+        for (Course course : timetable.getCourseList()){
+            courses.add(EntityConverter.generateCourseResponse(course));
+        }
+        return new TimetableModel(courses);
     }
 }

--- a/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInputBoundary.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInputBoundary.java
@@ -1,4 +1,4 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.application_business;
 
 import entities.Session;
 import entities.Timetable;

--- a/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInputBoundary.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInputBoundary.java
@@ -1,8 +1,5 @@
 package retrieve_timetable_use_case.application_business;
 
-import entities.Session;
-import entities.Timetable;
-
 /**
  * The input boundary used in the RetrieveTimetable use case.
  * All implementations should be able to retrieve the data of the entities below and return the
@@ -17,8 +14,4 @@ public interface RetrieveTimetableInputBoundary {
     TimetableModel retrieveTimetable();
 
     SessionModel retrieveSession();
-
-    void setSession(Session session);
-
-    void setTimetable(Timetable timetable);
 }

--- a/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInteractor.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInteractor.java
@@ -21,10 +21,7 @@ public class RetrieveTimetableInteractor implements RetrieveTimetableInputBounda
     private Timetable timetable;
     private Session session;
 
-    public RetrieveTimetableInteractor(Timetable timetable, Session session){
-        this.timetable = timetable;
-        this.session = session;
-    }
+    public RetrieveTimetableInteractor(){}
 
 
     /**

--- a/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInteractor.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInteractor.java
@@ -1,4 +1,4 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.application_business;
 
 import entities.Course;
 import entities.Session;

--- a/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInteractor.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInteractor.java
@@ -1,10 +1,8 @@
 package retrieve_timetable_use_case.application_business;
 
-import entities.Course;
 import entities.Session;
 import entities.Timetable;
 
-import java.util.ArrayList;
 import java.util.concurrent.Flow;
 
 /**
@@ -63,13 +61,8 @@ public class RetrieveTimetableInteractor implements RetrieveTimetableInputBounda
      */
     @Override
     public TimetableModel retrieveTimetable(){
-        ArrayList<CourseModel> courses = new ArrayList<>();
-        for (Course course : timetable.getCourseList()){
-            courses.add(EntityConverter.generateCourseResponse(course));
-        }
-        return new TimetableModel(courses);
+        return EntityConverter.generateTimetableResponse(timetable);
     }
-
 
     /**
      * @param subscription a new subscription.

--- a/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInteractor.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInteractor.java
@@ -50,12 +50,10 @@ public class RetrieveTimetableInteractor implements RetrieveTimetableInputBounda
         return EntityConverter.generateSessionResponse(session);
     }
 
-    @Override
     public void setSession(Session session) {
         this.session = session;
     }
 
-    @Override
     public void setTimetable(Timetable timetable) {
         this.timetable = timetable;
     }

--- a/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInteractor.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableInteractor.java
@@ -5,6 +5,7 @@ import entities.Session;
 import entities.Timetable;
 
 import java.util.ArrayList;
+import java.util.concurrent.Flow;
 
 /**
  * The main interactor used in the retrieve timetable use case. It uses EntityConverter's methods
@@ -15,7 +16,7 @@ import java.util.ArrayList;
  * session similarly refers to the Session currently into the interavtor, and retrieveCalendarCourse
  * calls will search through session.
  */
-public class RetrieveTimetableInteractor implements RetrieveTimetableInputBoundary {
+public class RetrieveTimetableInteractor implements RetrieveTimetableInputBoundary, Flow.Subscriber<Object> {
 
     private Timetable timetable;
     private Session session;
@@ -74,5 +75,47 @@ public class RetrieveTimetableInteractor implements RetrieveTimetableInputBounda
         return new TimetableModel(courses);
     }
 
+
+    /**
+     * @param subscription a new subscription.
+     *                     A method called when the interactor subscribes to a new Subscription. Currently does nothing.
+     */
+    @Override
+    public void onSubscribe(Flow.Subscription subscription) {
+
+    }
+
+    /**
+     * @param item the item passed to the interactor by its publishers, which will be other interactors.
+     *             item can either be a Timetable or Session, in which case the interactor's corresponding
+     *             instance attribute is updated to match it.
+     */
+    @Override
+    public void onNext(Object item) {
+        if (item instanceof Timetable){
+            this.timetable = (Timetable) item;
+        }
+        else if (item instanceof Session){
+            this.session = (Session) item;
+        }
+    }
+
+    /**
+     * @param throwable the exception encountered by either the Subscriber or Publisher.
+     *                  This method is called when a throwable is thrown by the Subscriber or Publisher, and
+     *                  currently does nothing.
+     */
+    @Override
+    public void onError(Throwable throwable) {
+
+    }
+
+    /**
+     * Method invoked when no other Subscriber method invocations will occur. Currently does nothing.
+     */
+    @Override
+    public void onComplete() {
+
+    }
 
 }

--- a/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableRequestModel.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/RetrieveTimetableRequestModel.java
@@ -1,4 +1,4 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.application_business;
 
 /**
  * A request model containing all requirements of a given retrieve timetable request.
@@ -25,8 +25,5 @@ public class RetrieveTimetableRequestModel {
     public String getTimetable() {
         return timetable;
     }
-
-    public String getSectionCode() {
-        return sectionCode;
-    }
+    
 }

--- a/src/main/java/retrieve_timetable_use_case/application_business/SectionModel.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/SectionModel.java
@@ -1,4 +1,4 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.application_business;
 
 import java.util.List;
 

--- a/src/main/java/retrieve_timetable_use_case/application_business/SectionModel.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/SectionModel.java
@@ -1,6 +1,8 @@
 package retrieve_timetable_use_case.application_business;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A data carrier class that doubles as a request and response model containing all information
@@ -39,6 +41,12 @@ public class SectionModel {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SectionModel that = (SectionModel) o;
-        return getCode().equals(that.getCode()) && getInstructor().equals(that.getInstructor()) && getBlocks().equals(that.getBlocks());
+        return getCode().equals(that.getCode()) && getInstructor().equals(that.getInstructor()) &&
+                new HashSet<>(getBlocks()).equals(new HashSet<>(that.getBlocks()));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(code, instructor) + blocks.size();
     }
 }

--- a/src/main/java/retrieve_timetable_use_case/application_business/SessionModel.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/SessionModel.java
@@ -1,4 +1,4 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.application_business;
 
 import java.util.HashMap;
 

--- a/src/main/java/retrieve_timetable_use_case/application_business/TimetableModel.java
+++ b/src/main/java/retrieve_timetable_use_case/application_business/TimetableModel.java
@@ -1,4 +1,4 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.application_business;
 
 import java.util.List;
 

--- a/src/main/java/retrieve_timetable_use_case/interface_adapters/RetrieveTimetableController.java
+++ b/src/main/java/retrieve_timetable_use_case/interface_adapters/RetrieveTimetableController.java
@@ -1,4 +1,9 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.interface_adapters;
+
+import retrieve_timetable_use_case.application_business.RetrieveTimetableInputBoundary;
+import retrieve_timetable_use_case.application_business.RetrieveTimetableRequestModel;
+import retrieve_timetable_use_case.application_business.CourseModel;
+import retrieve_timetable_use_case.application_business.TimetableModel;
 
 /**
  * The controller used in the RetrieveTimetableUseCase.

--- a/src/main/java/retrieve_timetable_use_case/interface_adapters/TimetableModelConverter.java
+++ b/src/main/java/retrieve_timetable_use_case/interface_adapters/TimetableModelConverter.java
@@ -1,5 +1,6 @@
-package retrieve_timetable_use_case;
+package retrieve_timetable_use_case.interface_adapters;
 
+import retrieve_timetable_use_case.application_business.*;
 import screens.*;
 
 import java.util.ArrayList;

--- a/src/main/java/screens/AddCoursePresenter.java
+++ b/src/main/java/screens/AddCoursePresenter.java
@@ -2,19 +2,11 @@ package screens;
 
 import edit_timetable_use_case.AddCourseOutputBoundary;
 import edit_timetable_use_case.EditTimetableResponseModel;
-import edit_timetable_use_case.RemoveCourseFailedException;
-import retrieve_timetable_use_case.TimetableModel;
-import retrieve_timetable_use_case.TimetableModelConverter;
-import retrieve_timetable_use_case.TimetableModelConverter;
-import retrieve_timetable_use_case.TimetableModel;
+import retrieve_timetable_use_case.application_business.TimetableModel;
+import retrieve_timetable_use_case.interface_adapters.TimetableModelConverter;
 
 public class AddCoursePresenter implements AddCourseOutputBoundary {
     private EditTimetableView view;
-
-    /**
-     * @param
-     * @return
-     */
 
     public AddCoursePresenter(){}
     public AddCoursePresenter(EditTimetableView view){

--- a/src/main/java/screens/EditCourseScreen.java
+++ b/src/main/java/screens/EditCourseScreen.java
@@ -1,6 +1,6 @@
 /*package screens;
 
-import retrieve_timetable_use_case.RetrieveTimetableController;
+import retrieve_timetable_use_case.interface_adapters.RetrieveTimetableController;
 import entities.Section;
 
 import javax.swing.*;

--- a/src/main/java/screens/RecommendBRPresenter.java
+++ b/src/main/java/screens/RecommendBRPresenter.java
@@ -1,9 +1,9 @@
 package screens;
 
 import recommend_br_use_case.*;
-import retrieve_timetable_use_case.BlockModel;
-import retrieve_timetable_use_case.CourseModel;
-import retrieve_timetable_use_case.SectionModel;
+import retrieve_timetable_use_case.application_business.BlockModel;
+import retrieve_timetable_use_case.application_business.CourseModel;
+import retrieve_timetable_use_case.application_business.SectionModel;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/screens/RemoveCoursePresenter.java
+++ b/src/main/java/screens/RemoveCoursePresenter.java
@@ -2,15 +2,12 @@ package screens;
 
 import edit_timetable_use_case.RemoveCourseOutputBoundary;
 import edit_timetable_use_case.EditTimetableResponseModel;
-import edit_timetable_use_case.RemoveCourseFailedException;
-import retrieve_timetable_use_case.TimetableModel;
-import retrieve_timetable_use_case.TimetableModelConverter;
-import retrieve_timetable_use_case.TimetableModel;
+import retrieve_timetable_use_case.application_business.TimetableModel;
+import retrieve_timetable_use_case.interface_adapters.TimetableModelConverter;
 
 /**
  * The presenter used in the RemoveCourse use case.
  * This presenter must have a EditTimetableView set to it before being used (see SetView).
- *
  * View is the view that the presenter updates.
  */
 public class RemoveCoursePresenter implements RemoveCourseOutputBoundary {

--- a/src/test/java/edit_timetable_use_case/EditTimetableControllerTest.java
+++ b/src/test/java/edit_timetable_use_case/EditTimetableControllerTest.java
@@ -24,11 +24,10 @@ class EditTimetableControllerTest {
     @BeforeEach
     void setUp() {
         try{
-            TimetableCourse c = new TimetableCourse("", new ArrayList<Section>(),
+            TimetableCourse c = new TimetableCourse("", new ArrayList<>(),
                 "", "EGX101", "");
-            ArrayList<TimetableCourse> courses = new ArrayList<TimetableCourse>(List.of(c));
+            ArrayList<TimetableCourse> courses = new ArrayList<>(List.of(c));
             Timetable t = new Timetable(courses, "F");
-            Session s = new Session("F");
             view = new TestEditTimetableView();
             RemoveCourseOutputBoundary RCPresenter = new RemoveCoursePresenter();
             RCPresenter.setView(view);
@@ -53,7 +52,6 @@ class EditTimetableControllerTest {
     void removeSucceeds() {
         try {
             controller.remove("EGX101");
-            assertTrue(true);
         }
         catch (RemoveCourseFailedException e){
             fail("This call should not have resulted in a RemoveCourseFailedException.");

--- a/src/test/java/edit_timetable_use_case/RemoveCourseInteractorTest.java
+++ b/src/test/java/edit_timetable_use_case/RemoveCourseInteractorTest.java
@@ -1,7 +1,6 @@
 package edit_timetable_use_case;
 
 import entities.InvalidSectionsException;
-import entities.Section;
 import entities.Timetable;
 import entities.TimetableCourse;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,9 +21,9 @@ class RemoveCourseInteractorTest {
     @BeforeEach
     public void setUp(){
         try{
-            c = new TimetableCourse("", new ArrayList<Section>(),
+            c = new TimetableCourse("", new ArrayList<>(),
                     "", "EGX101", "");
-            ArrayList<TimetableCourse> courses = new ArrayList<TimetableCourse>(List.of(c));
+            ArrayList<TimetableCourse> courses = new ArrayList<>(List.of(c));
             t = new Timetable(courses, "F");
             RemoveCourseOutputBoundary presenter = new RemoveCoursePresenter();
             interactor = new RemoveCourseInteractor(presenter);
@@ -59,7 +58,7 @@ class RemoveCourseInteractorTest {
 
     @Test
     void removeFails(){
-        EditTimetableRequestModel request = new EditTimetableRequestModel("NAC300", new ArrayList<String>());
+        EditTimetableRequestModel request = new EditTimetableRequestModel("NAC300", new ArrayList<>());
         try{
             interactor.remove(request);
             fail("Interactor should have thrown RemoveCourseFailed exception.");

--- a/src/test/java/edit_timetable_use_case/TestEditTimetableView.java
+++ b/src/test/java/edit_timetable_use_case/TestEditTimetableView.java
@@ -10,17 +10,12 @@ public class TestEditTimetableView implements EditTimetableView {
 
     public String response;
     public TimetableViewModel timetable;
-    /**
-     * @param timetable
-     */
+
     @Override
     public void updateTimetable(TimetableViewModel timetable) {
         this.timetable = timetable;
     }
 
-    /**
-     * @param successMessage
-     */
     @Override
     public void displayResponse(String successMessage) {
         this.response = successMessage;

--- a/src/test/java/retrieve_timetable_use_case/BlockModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/BlockModelTest.java
@@ -28,4 +28,10 @@ class BlockModelTest {
     void testNotEquals() {
         assertNotEquals(new BlockModel(2, 14, 16, "OT104"), block);
     }
+
+    @Test
+    void testHashCode(){
+        assertEquals(new BlockModel(2, 14, 16, "AB106").hashCode(), block.hashCode());
+    }
+
 }

--- a/src/test/java/retrieve_timetable_use_case/BlockModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/BlockModelTest.java
@@ -1,0 +1,20 @@
+package retrieve_timetable_use_case;
+
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BlockModelTest {
+    private BlockModel block;
+
+    @Before
+    public void setUp() {
+        block = new BlockModel(2, 14, 16, "AB107");
+    }
+
+    @Test
+    void testEquals() {
+        assertEquals(block, new BlockModel(2, 14, 16, "AB107"));
+    }
+}

--- a/src/test/java/retrieve_timetable_use_case/BlockModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/BlockModelTest.java
@@ -6,6 +6,11 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+/**
+ * A test suite for the BlockModel class, primarily to confirm the correctness of BlockModel's equal method.
+ * The setters and getters are currently too simple to require testing, but must be tested if more complex
+ * behaviour is introduced.
+ */
 class BlockModelTest {
     private BlockModel block;
 

--- a/src/test/java/retrieve_timetable_use_case/BlockModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/BlockModelTest.java
@@ -2,6 +2,7 @@ package retrieve_timetable_use_case;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import retrieve_timetable_use_case.application_business.BlockModel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/src/test/java/retrieve_timetable_use_case/BlockModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/BlockModelTest.java
@@ -1,0 +1,25 @@
+package retrieve_timetable_use_case;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class BlockModelTest {
+    private BlockModel block;
+
+    @BeforeEach
+    public void setUp() {
+        block = new BlockModel(2, 14, 16, "AB106");
+    }
+    @Test
+    void testEquals() {
+        assertEquals(new BlockModel(2, 14, 16, "AB106"), block);
+    }
+
+    @Test
+    void testNotEquals() {
+        assertNotEquals(new BlockModel(2, 14, 16, "OT104"), block);
+    }
+}

--- a/src/test/java/retrieve_timetable_use_case/CourseModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/CourseModelTest.java
@@ -2,11 +2,13 @@ package retrieve_timetable_use_case;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import retrieve_timetable_use_case.application_business.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * A test suite for the CourseModel class, primarily to confirm the correctness of BlockModel's equal method.

--- a/src/test/java/retrieve_timetable_use_case/CourseModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/CourseModelTest.java
@@ -8,6 +8,11 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * A test suite for the CourseModel class, primarily to confirm the correctness of BlockModel's equal method.
+ * The setters and getters are currently too simple to require testing, but must be tested if more complex
+ * behaviour is introduced.
+ */
 class CourseModelTest {
     private CourseModel course;
 

--- a/src/test/java/retrieve_timetable_use_case/CourseModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/CourseModelTest.java
@@ -1,0 +1,33 @@
+package retrieve_timetable_use_case;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CourseModelTest {
+    private CourseModel course;
+
+    @BeforeEach
+    public void setUp() {
+        List<SectionModel> sections = new ArrayList<>();
+        sections.add(new SectionModel("LEC0101", "prof!!", new ArrayList<>()));
+        course = new CourseModel("title", sections, "F", "EGG100", "BR1");
+    }
+
+    @Test
+    void testEquals() {
+        List<SectionModel> sections = new ArrayList<>();
+        sections.add(new SectionModel("LEC0101", "prof!!", new ArrayList<>()));
+        assertEquals(new CourseModel("title", sections, "F", "EGG100", "BR1"), course);
+    }
+
+    @Test
+    void testNotEquals() {
+        List<SectionModel> otherSections = new ArrayList<>();
+        assertNotEquals(new CourseModel("title", otherSections, "F", "EGG100", "BR1"), course);
+    }
+}

--- a/src/test/java/retrieve_timetable_use_case/EntityConverterTest.java
+++ b/src/test/java/retrieve_timetable_use_case/EntityConverterTest.java
@@ -1,28 +1,75 @@
 package retrieve_timetable_use_case;
 
-import entities.Block;
-import entities.Course;
-import entities.Section;
+import entities.*;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EntityConverterTest {
+    private BlockModel blockModel;
+    private Block blockActual;
+    private SectionModel sectionModel;
+    private Section sectionActual;
+    private CourseModel courseModel;
+    private CalendarCourse courseActual;
+    private SessionModel sessionModel;
+    private Session sessionActual;
+
+    @BeforeEach
+    public void setUp() {
+        blockModel = new BlockModel(2, 14, 16, "AB106");
+        blockActual = new Block("WE", "14:00", "16:00", "AB106");
+
+        ArrayList<BlockModel> modelBlocks = new ArrayList<>();
+        modelBlocks.add(blockModel);
+
+        ArrayList<Block> actualBlocks = new ArrayList<>();
+        actualBlocks.add(blockActual);
+
+        sectionActual = new Section("LEC0101", "prof!!", actualBlocks);
+        sectionModel = new SectionModel("LEC0101", "prof!!", modelBlocks);
+
+        ArrayList<SectionModel> modelSections = new ArrayList<>();
+        modelSections.add(sectionModel);
+
+        ArrayList<Section> actualSections = new ArrayList<>();
+        actualSections.add(sectionActual);
+
+        courseModel = new CourseModel("some course", modelSections, "F", "EGG100", "" +
+                "BR1");
+        courseActual = new CalendarCourse("some course", actualSections, "F", "EGG100", "" +
+                "BR1");
+
+        HashMap<String, CourseModel> modelCourses = new HashMap<>();
+        modelCourses.put(courseModel.getCourseCode(), courseModel);
+
+        sessionModel = new SessionModel(modelCourses, "F");
+        sessionActual = new Session("F");
+        sessionActual.addCourse(courseActual);
+    }
 
     @Test
     void generateSessionResponse() {
+        assertEquals(sessionModel, EntityConverter.generateSessionResponse(sessionActual));
     }
 
     @Test
     void generateCourseResponse() {
+        assertEquals(courseModel, EntityConverter.generateCourseResponse(courseActual));
     }
 
     @Test
     void generateSectionResponse() {
+        assertEquals(sectionModel, EntityConverter.generateSectionResponse(sectionActual));
     }
 
     @Test
     void generateBlockResponse() {
+        assertEquals(blockModel, EntityConverter.generateBlockResponse(blockActual));
     }
 
 }

--- a/src/test/java/retrieve_timetable_use_case/EntityConverterTest.java
+++ b/src/test/java/retrieve_timetable_use_case/EntityConverterTest.java
@@ -9,6 +9,9 @@ import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * A suite of tests for the EntityConverter class of static methods.
+ */
 class EntityConverterTest {
     private BlockModel blockModel;
     private Block blockActual;
@@ -19,6 +22,10 @@ class EntityConverterTest {
     private SessionModel sessionModel;
     private Session sessionActual;
 
+    /**
+     * Creates a set of timetable data structures (Sessions, Timetables, Courses, Sections, Blocks) and their
+     * corresponding Models, which are each encapsulated by the structure that is one layer higher than it.
+     */
     @BeforeEach
     public void setUp() {
         blockModel = new BlockModel(2, 14, 16, "AB106");
@@ -52,21 +59,33 @@ class EntityConverterTest {
         sessionActual.addCourse(courseActual);
     }
 
+    /**
+     * Tests that the model created by generateSessionResponse has data equivalent to the input session.
+     */
     @Test
     void generateSessionResponse() {
         assertEquals(sessionModel, EntityConverter.generateSessionResponse(sessionActual));
     }
 
+    /**
+     * Tests that the model created by generateCourseResponse has data equivalent to the input session.
+     */
     @Test
     void generateCourseResponse() {
         assertEquals(courseModel, EntityConverter.generateCourseResponse(courseActual));
     }
 
+    /**
+     * Tests that the model created by generateSectionResponse has data equivalent to the input session.
+     */
     @Test
     void generateSectionResponse() {
         assertEquals(sectionModel, EntityConverter.generateSectionResponse(sectionActual));
     }
 
+    /**
+     * Tests that the model created by generateBlockResponse has data equivalent to the input session.
+     */
     @Test
     void generateBlockResponse() {
         assertEquals(blockModel, EntityConverter.generateBlockResponse(blockActual));

--- a/src/test/java/retrieve_timetable_use_case/EntityConverterTest.java
+++ b/src/test/java/retrieve_timetable_use_case/EntityConverterTest.java
@@ -1,0 +1,28 @@
+package retrieve_timetable_use_case;
+
+import entities.Block;
+import entities.Course;
+import entities.Section;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EntityConverterTest {
+
+    @Test
+    void generateSessionResponse() {
+    }
+
+    @Test
+    void generateCourseResponse() {
+    }
+
+    @Test
+    void generateSectionResponse() {
+    }
+
+    @Test
+    void generateBlockResponse() {
+    }
+
+}

--- a/src/test/java/retrieve_timetable_use_case/EntityConverterTest.java
+++ b/src/test/java/retrieve_timetable_use_case/EntityConverterTest.java
@@ -1,13 +1,16 @@
 package retrieve_timetable_use_case;
 
-import entities.*;
+import entities.Block;
+import entities.CalendarCourse;
+import entities.Section;
+import entities.Session;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import retrieve_timetable_use_case.application_business.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * A suite of tests for the EntityConverter class of static methods.
@@ -64,7 +67,7 @@ class EntityConverterTest {
      */
     @Test
     void generateSessionResponse() {
-        assertEquals(sessionModel, EntityConverter.generateSessionResponse(sessionActual));
+        Assertions.assertEquals(sessionModel, EntityConverter.generateSessionResponse(sessionActual));
     }
 
     /**
@@ -72,7 +75,7 @@ class EntityConverterTest {
      */
     @Test
     void generateCourseResponse() {
-        assertEquals(courseModel, EntityConverter.generateCourseResponse(courseActual));
+        Assertions.assertEquals(courseModel, EntityConverter.generateCourseResponse(courseActual));
     }
 
     /**
@@ -80,7 +83,7 @@ class EntityConverterTest {
      */
     @Test
     void generateSectionResponse() {
-        assertEquals(sectionModel, EntityConverter.generateSectionResponse(sectionActual));
+        Assertions.assertEquals(sectionModel, EntityConverter.generateSectionResponse(sectionActual));
     }
 
     /**
@@ -88,7 +91,7 @@ class EntityConverterTest {
      */
     @Test
     void generateBlockResponse() {
-        assertEquals(blockModel, EntityConverter.generateBlockResponse(blockActual));
+        Assertions.assertEquals(blockModel, EntityConverter.generateBlockResponse(blockActual));
     }
 
 }

--- a/src/test/java/retrieve_timetable_use_case/RetrieveTimetableControllerTest.java
+++ b/src/test/java/retrieve_timetable_use_case/RetrieveTimetableControllerTest.java
@@ -1,0 +1,85 @@
+package retrieve_timetable_use_case;
+
+import entities.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RetrieveTimetableControllerTest {
+
+    private CourseModel courseModel;
+    private TimetableModel timetableModel;
+
+    private RetrieveTimetableController controller;
+
+    @BeforeEach
+    void setUp() {
+
+        BlockModel blockModel = new BlockModel(2, 14, 16, "AB106");
+        Block blockActual = new Block("WE", "14:00", "16:00", "AB106");
+
+        ArrayList<BlockModel> modelBlocks = new ArrayList<>();
+        modelBlocks.add(blockModel);
+
+        ArrayList<Block> actualBlocks = new ArrayList<>();
+        actualBlocks.add(blockActual);
+
+        Section sectionActual = new Section("LEC0101", "prof!!", actualBlocks);
+        SectionModel sectionModel = new SectionModel("LEC0101", "prof!!", modelBlocks);
+
+        ArrayList<SectionModel> modelSections = new ArrayList<>();
+        modelSections.add(sectionModel);
+
+        ArrayList<Section> actualSections = new ArrayList<>();
+        actualSections.add(sectionActual);
+
+        courseModel = new CourseModel("some course", modelSections, "F", "EGG100", "" +
+                "BR1");
+        CalendarCourse courseActual = new CalendarCourse("some course", actualSections, "F", "EGG100", "" +
+                "BR1");
+        try {
+            ArrayList<TimetableCourse> timetableCourses = new ArrayList<>();
+            timetableCourses.add(new TimetableCourse("some course", actualSections, "F",
+                    "EGG100", "BR1"));
+
+            ArrayList<CourseModel> timetableModelCourses = new ArrayList<>();
+            timetableModelCourses.add(courseModel);
+
+            Session sessionActual = new Session("F");
+            sessionActual.addCourse(courseActual);
+
+            Timetable timetable = new Timetable(timetableCourses, "F");
+
+            timetableModel = new TimetableModel(timetableModelCourses);
+
+            RetrieveTimetableInteractor interactor = new RetrieveTimetableInteractor(timetable, sessionActual);
+
+            controller = new RetrieveTimetableController(interactor);
+        }
+        catch (InvalidSectionsException ignored){
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void retrieveCalendarCourse() {
+        assertEquals(controller.retrieveCalendarCourse("EGG100"), courseModel);
+    }
+
+    @Test
+    void retrieveTimetableCourse() {
+        assertEquals(controller.retrieveTimetableCourse("EGG100"), courseModel);
+    }
+
+    @Test
+    void retrieveTimetable() {
+        assertEquals(controller.retrieveTimetable(), timetableModel);
+    }
+}

--- a/src/test/java/retrieve_timetable_use_case/RetrieveTimetableControllerTest.java
+++ b/src/test/java/retrieve_timetable_use_case/RetrieveTimetableControllerTest.java
@@ -2,12 +2,13 @@ package retrieve_timetable_use_case;
 
 import entities.*;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import retrieve_timetable_use_case.application_business.*;
+import retrieve_timetable_use_case.interface_adapters.RetrieveTimetableController;
 
 import java.util.ArrayList;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * A suite of tests for RetrieveTimetableController.
@@ -81,7 +82,7 @@ class RetrieveTimetableControllerTest {
      */
     @Test
     void retrieveCalendarCourse() {
-        assertEquals(controller.retrieveCalendarCourse("EGG100"), courseModel);
+        Assertions.assertEquals(controller.retrieveCalendarCourse("EGG100"), courseModel);
     }
 
     /**
@@ -90,7 +91,7 @@ class RetrieveTimetableControllerTest {
      */
     @Test
     void retrieveTimetableCourse() {
-        assertEquals(controller.retrieveTimetableCourse("EGG100"), courseModel);
+        Assertions.assertEquals(controller.retrieveTimetableCourse("EGG100"), courseModel);
     }
 
     /**
@@ -99,6 +100,6 @@ class RetrieveTimetableControllerTest {
      */
     @Test
     void retrieveTimetable() {
-        assertEquals(controller.retrieveTimetable(), timetableModel);
+        Assertions.assertEquals(controller.retrieveTimetable(), timetableModel);
     }
 }

--- a/src/test/java/retrieve_timetable_use_case/RetrieveTimetableControllerTest.java
+++ b/src/test/java/retrieve_timetable_use_case/RetrieveTimetableControllerTest.java
@@ -64,7 +64,9 @@ class RetrieveTimetableControllerTest {
 
             timetableModel = new TimetableModel(timetableModelCourses);
 
-            RetrieveTimetableInteractor interactor = new RetrieveTimetableInteractor(timetable, sessionActual);
+            RetrieveTimetableInteractor interactor = new RetrieveTimetableInteractor();
+            interactor.setTimetable(timetable);
+            interactor.setSession(sessionActual);
 
             controller = new RetrieveTimetableController(interactor);
         }

--- a/src/test/java/retrieve_timetable_use_case/RetrieveTimetableControllerTest.java
+++ b/src/test/java/retrieve_timetable_use_case/RetrieveTimetableControllerTest.java
@@ -9,6 +9,9 @@ import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * A suite of tests for RetrieveTimetableController.
+ */
 class RetrieveTimetableControllerTest {
 
     private CourseModel courseModel;
@@ -16,6 +19,10 @@ class RetrieveTimetableControllerTest {
 
     private RetrieveTimetableController controller;
 
+    /**
+     * Sets up the controller, as well as a set of timetable data structures and their corresponding models for later
+     * comparison.
+     */
     @BeforeEach
     void setUp() {
 
@@ -68,16 +75,28 @@ class RetrieveTimetableControllerTest {
     void tearDown() {
     }
 
+    /**
+     * Tests that the object returned by a call of retrieveCalendarCourse has data equivalent to the corresponding
+     * CalendarCourse. (See TimetableCourse.equals() for further details).
+     */
     @Test
     void retrieveCalendarCourse() {
         assertEquals(controller.retrieveCalendarCourse("EGG100"), courseModel);
     }
 
+    /**
+     * Tests that the object returned by a call of retrieveTimetableCourse has data equivalent to the corresponding
+     * TimetableCourse. (See TimetableCourse.equals() for further details).
+     */
     @Test
     void retrieveTimetableCourse() {
         assertEquals(controller.retrieveTimetableCourse("EGG100"), courseModel);
     }
 
+    /**
+     * Tests that the object returned by a call of retrieveTimetable has data equivalent to the corresponding
+     * Timetable. (See Timetable.equals() for further details).
+     */
     @Test
     void retrieveTimetable() {
         assertEquals(controller.retrieveTimetable(), timetableModel);

--- a/src/test/java/retrieve_timetable_use_case/RetrieveTimetableInteractorTest.java
+++ b/src/test/java/retrieve_timetable_use_case/RetrieveTimetableInteractorTest.java
@@ -9,12 +9,19 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * A suite of tests for the RetrieveTimetableInteractor.
+ */
 class RetrieveTimetableInteractorTest {
     private RetrieveTimetableInteractor interactor;
     private CourseModel courseModel;
     private SessionModel sessionModel;
     private TimetableModel timetableModel;
 
+    /**
+     * Creates a mock-up session and timetable with non-empty courses, sections and blocks, as well as
+     * equivalent Models.
+     */
     @BeforeEach
     void setUp() {
         BlockModel blockModel = new BlockModel(2, 14, 16, "AB106");
@@ -69,6 +76,9 @@ class RetrieveTimetableInteractorTest {
     void tearDown() {
     }
 
+    /**
+     * Asserts that the CourseModel object returned by the interactor is equivalent to the input TimetableCourse.
+     */
     @Test
     void retrieveTimetableCourse() {
         RetrieveTimetableRequestModel request = new RetrieveTimetableRequestModel(
@@ -76,6 +86,9 @@ class RetrieveTimetableInteractorTest {
         assertEquals(courseModel, interactor.retrieveTimetableCourse(request));
     }
 
+    /**
+     * Asserts that the CourseModel object returned by the interactor is equivalent to the input CalendarCourse.
+     */
     @Test
     void retrieveCalendarCourse() {
         RetrieveTimetableRequestModel request = new RetrieveTimetableRequestModel(
@@ -83,11 +96,17 @@ class RetrieveTimetableInteractorTest {
         assertEquals(courseModel, interactor.retrieveCalendarCourse(request));
     }
 
+    /**
+     * Asserts that the SessionModel object returned by the interactor is equivalent to the input Session.
+     */
     @Test
     void retrieveSession() {
         assertEquals(sessionModel, interactor.retrieveSession());
     }
 
+    /**
+     * Asserts that the TimetableModel object returned by the interactor is equivalent to the input Timetable.
+     */
     @Test
     void retrieveTimetable() {
         assertEquals(timetableModel, interactor.retrieveTimetable());

--- a/src/test/java/retrieve_timetable_use_case/RetrieveTimetableInteractorTest.java
+++ b/src/test/java/retrieve_timetable_use_case/RetrieveTimetableInteractorTest.java
@@ -2,12 +2,13 @@ package retrieve_timetable_use_case;
 
 import entities.*;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import retrieve_timetable_use_case.application_business.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * A suite of tests for the RetrieveTimetableInteractor.
@@ -83,7 +84,7 @@ class RetrieveTimetableInteractorTest {
     void retrieveTimetableCourse() {
         RetrieveTimetableRequestModel request = new RetrieveTimetableRequestModel(
                 "", "EGG100", "");
-        assertEquals(courseModel, interactor.retrieveTimetableCourse(request));
+        Assertions.assertEquals(courseModel, interactor.retrieveTimetableCourse(request));
     }
 
     /**
@@ -93,7 +94,7 @@ class RetrieveTimetableInteractorTest {
     void retrieveCalendarCourse() {
         RetrieveTimetableRequestModel request = new RetrieveTimetableRequestModel(
                 "", "EGG100", "");
-        assertEquals(courseModel, interactor.retrieveCalendarCourse(request));
+        Assertions.assertEquals(courseModel, interactor.retrieveCalendarCourse(request));
     }
 
     /**
@@ -101,7 +102,7 @@ class RetrieveTimetableInteractorTest {
      */
     @Test
     void retrieveSession() {
-        assertEquals(sessionModel, interactor.retrieveSession());
+        Assertions.assertEquals(sessionModel, interactor.retrieveSession());
     }
 
     /**
@@ -109,6 +110,6 @@ class RetrieveTimetableInteractorTest {
      */
     @Test
     void retrieveTimetable() {
-        assertEquals(timetableModel, interactor.retrieveTimetable());
+        Assertions.assertEquals(timetableModel, interactor.retrieveTimetable());
     }
 }

--- a/src/test/java/retrieve_timetable_use_case/RetrieveTimetableInteractorTest.java
+++ b/src/test/java/retrieve_timetable_use_case/RetrieveTimetableInteractorTest.java
@@ -1,0 +1,95 @@
+package retrieve_timetable_use_case;
+
+import entities.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RetrieveTimetableInteractorTest {
+    private RetrieveTimetableInteractor interactor;
+    private CourseModel courseModel;
+    private SessionModel sessionModel;
+    private TimetableModel timetableModel;
+
+    @BeforeEach
+    void setUp() {
+        BlockModel blockModel = new BlockModel(2, 14, 16, "AB106");
+        Block blockActual = new Block("WE", "14:00", "16:00", "AB106");
+
+        ArrayList<BlockModel> modelBlocks = new ArrayList<>();
+        modelBlocks.add(blockModel);
+
+        ArrayList<Block> actualBlocks = new ArrayList<>();
+        actualBlocks.add(blockActual);
+
+        Section sectionActual = new Section("LEC0101", "prof!!", actualBlocks);
+        SectionModel sectionModel = new SectionModel("LEC0101", "prof!!", modelBlocks);
+
+        ArrayList<SectionModel> modelSections = new ArrayList<>();
+        modelSections.add(sectionModel);
+
+        ArrayList<Section> actualSections = new ArrayList<>();
+        actualSections.add(sectionActual);
+
+        courseModel = new CourseModel("some course", modelSections, "F", "EGG100", "" +
+                "BR1");
+        CalendarCourse courseActual = new CalendarCourse("some course", actualSections, "F", "EGG100", "" +
+                "BR1");
+
+        HashMap<String, CourseModel> modelCourses = new HashMap<>();
+        try {
+            ArrayList<TimetableCourse> timetableCourses = new ArrayList<>();
+            timetableCourses.add(new TimetableCourse("some course", actualSections, "F",
+                    "EGG100", "BR1"));
+
+            ArrayList<CourseModel> timetableModelCourses = new ArrayList<>();
+            timetableModelCourses.add(courseModel);
+
+            modelCourses.put(courseModel.getCourseCode(), courseModel);
+
+            sessionModel = new SessionModel(modelCourses, "F");
+            Session sessionActual = new Session("F");
+            sessionActual.addCourse(courseActual);
+
+            Timetable timetable = new Timetable(timetableCourses, "F");
+
+            timetableModel = new TimetableModel(timetableModelCourses);
+
+            interactor = new RetrieveTimetableInteractor(timetable, sessionActual);
+        }
+        catch (InvalidSectionsException ignored){
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void retrieveTimetableCourse() {
+        RetrieveTimetableRequestModel request = new RetrieveTimetableRequestModel(
+                "", "EGG100", "");
+        assertEquals(courseModel, interactor.retrieveTimetableCourse(request));
+    }
+
+    @Test
+    void retrieveCalendarCourse() {
+        RetrieveTimetableRequestModel request = new RetrieveTimetableRequestModel(
+                "", "EGG100", "");
+        assertEquals(courseModel, interactor.retrieveCalendarCourse(request));
+    }
+
+    @Test
+    void retrieveSession() {
+        assertEquals(sessionModel, interactor.retrieveSession());
+    }
+
+    @Test
+    void retrieveTimetable() {
+        assertEquals(timetableModel, interactor.retrieveTimetable());
+    }
+}

--- a/src/test/java/retrieve_timetable_use_case/RetrieveTimetableInteractorTest.java
+++ b/src/test/java/retrieve_timetable_use_case/RetrieveTimetableInteractorTest.java
@@ -67,7 +67,9 @@ class RetrieveTimetableInteractorTest {
 
             timetableModel = new TimetableModel(timetableModelCourses);
 
-            interactor = new RetrieveTimetableInteractor(timetable, sessionActual);
+            interactor = new RetrieveTimetableInteractor();
+            interactor.setTimetable(timetable);
+            interactor.setSession(sessionActual);
         }
         catch (InvalidSectionsException ignored){
         }

--- a/src/test/java/retrieve_timetable_use_case/SectionModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/SectionModelTest.java
@@ -1,6 +1,6 @@
 package retrieve_timetable_use_case;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -10,9 +10,9 @@ import static org.junit.jupiter.api.Assertions.*;
 class SectionModelTest {
     private SectionModel section;
 
-    @Before
+    @BeforeEach
     public void SetUp() {
-        ArrayList<BlockModel> blocks = new ArrayList<BlockModel>();
+        ArrayList<BlockModel> blocks = new ArrayList<>();
         blocks.add(new BlockModel(0, 1, 2, ""));
         section = new SectionModel("CSC108", "prof!!", blocks);
 
@@ -20,8 +20,17 @@ class SectionModelTest {
 
     @Test
     void testEquals() {
-        ArrayList<BlockModel> blocks = new ArrayList<BlockModel>();
+        ArrayList<BlockModel> blocks = new ArrayList<>();
         blocks.add(new BlockModel(0, 1, 2, ""));
-        assertEquals(section, new SectionModel("CSC108", "prof!!", blocks));
+        SectionModel other = new SectionModel("CSC108", "prof!!", blocks);
+        assertEquals(other, section);
+    }
+
+    @Test
+    void testNotEquals() {
+        ArrayList<BlockModel> otherBlocks = new ArrayList<>();
+        otherBlocks.add(new BlockModel(2, 14, 16, "AB105"));
+        SectionModel other = new SectionModel("CSC108", "prof!!", otherBlocks);
+        assertNotEquals(other, section);
     }
 }

--- a/src/test/java/retrieve_timetable_use_case/SectionModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/SectionModelTest.java
@@ -7,6 +7,11 @@ import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * A test suite for the SectionModel class, primarily to confirm the correctness of its equal method.
+ * The setters and getters are currently too simple to require testing, but must be tested if more complex
+ * behaviour is introduced.
+ */
 class SectionModelTest {
     private SectionModel section;
 
@@ -18,6 +23,9 @@ class SectionModelTest {
 
     }
 
+    /**
+     * Tests that the Block and its equivalent BlockModel are considered equal.
+     */
     @Test
     void testEquals() {
         ArrayList<BlockModel> blocks = new ArrayList<>();
@@ -26,6 +34,9 @@ class SectionModelTest {
         assertEquals(other, section);
     }
 
+    /**
+     * Tests that the Block and a non-equivalent BlockModel are non-equal.
+     */
     @Test
     void testNotEquals() {
         ArrayList<BlockModel> otherBlocks = new ArrayList<>();

--- a/src/test/java/retrieve_timetable_use_case/SectionModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/SectionModelTest.java
@@ -2,10 +2,12 @@ package retrieve_timetable_use_case;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import retrieve_timetable_use_case.application_business.*;
 
 import java.util.ArrayList;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * A test suite for the SectionModel class, primarily to confirm the correctness of its equal method.

--- a/src/test/java/retrieve_timetable_use_case/SectionModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/SectionModelTest.java
@@ -46,4 +46,15 @@ class SectionModelTest {
         SectionModel other = new SectionModel("CSC108", "prof!!", otherBlocks);
         assertNotEquals(other, section);
     }
+
+    /**
+     * Tests that the Block and its equivalent BlockModel are considered has the same hash code.
+     */
+    @Test
+    void testHashCode(){
+        ArrayList<BlockModel> blocks = new ArrayList<>();
+        blocks.add(new BlockModel(0, 1, 2, ""));
+        SectionModel other = new SectionModel("CSC108", "prof!!", blocks);
+        assertEquals(other.hashCode(), section.hashCode());
+    }
 }

--- a/src/test/java/retrieve_timetable_use_case/SectionModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/SectionModelTest.java
@@ -1,0 +1,27 @@
+package retrieve_timetable_use_case;
+
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SectionModelTest {
+    private SectionModel section;
+
+    @Before
+    public void SetUp() {
+        ArrayList<BlockModel> blocks = new ArrayList<BlockModel>();
+        blocks.add(new BlockModel(0, 1, 2, ""));
+        section = new SectionModel("CSC108", "prof!!", blocks);
+
+    }
+
+    @Test
+    void testEquals() {
+        ArrayList<BlockModel> blocks = new ArrayList<BlockModel>();
+        blocks.add(new BlockModel(0, 1, 2, ""));
+        assertEquals(section, new SectionModel("CSC108", "prof!!", blocks));
+    }
+}

--- a/src/test/java/retrieve_timetable_use_case/SessionModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/SessionModelTest.java
@@ -1,0 +1,36 @@
+package retrieve_timetable_use_case;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionModelTest {
+    private SessionModel session;
+
+    @BeforeEach
+    void setUp() {
+        HashMap<String, CourseModel> courses = new HashMap<>();
+        courses.put("SD204", (new CourseModel("Something cool", new ArrayList<>(), "F", "SD204", "BR1")));
+        session = new SessionModel(courses, "F");
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void testEquals() {
+        HashMap<String, CourseModel> courses = new HashMap<>();
+        courses.put("SD204", (new CourseModel("Something cool", new ArrayList<>(), "F", "SD204", "BR1")));
+        assertEquals(new SessionModel(courses, "F"), session);
+    }
+
+    @Test
+    void testNotEquals() {
+        assertNotEquals(new SessionModel(new HashMap<>(), "F"), session);
+    }
+}

--- a/src/test/java/retrieve_timetable_use_case/SessionModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/SessionModelTest.java
@@ -3,10 +3,13 @@ package retrieve_timetable_use_case;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import retrieve_timetable_use_case.application_business.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * A test suite for the SessionModel class, primarily to confirm the correctness of its equal method.

--- a/src/test/java/retrieve_timetable_use_case/SessionModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/SessionModelTest.java
@@ -8,6 +8,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * A test suite for the SessionModel class, primarily to confirm the correctness of its equal method.
+ * The setters and getters are currently too simple to require testing, but must be tested if more complex
+ * behaviour is introduced.
+ */
 class SessionModelTest {
     private SessionModel session;
 
@@ -22,6 +27,9 @@ class SessionModelTest {
     void tearDown() {
     }
 
+    /**
+     * Tests that the Session and its equivalent SessionModel are considered equal.
+     */
     @Test
     void testEquals() {
         HashMap<String, CourseModel> courses = new HashMap<>();
@@ -29,6 +37,9 @@ class SessionModelTest {
         assertEquals(new SessionModel(courses, "F"), session);
     }
 
+    /**
+     * Tests that the Session and a non-equivalent SessionModel are non-equal.
+     */
     @Test
     void testNotEquals() {
         assertNotEquals(new SessionModel(new HashMap<>(), "F"), session);

--- a/src/test/java/retrieve_timetable_use_case/TimetableModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/TimetableModelTest.java
@@ -1,0 +1,39 @@
+package retrieve_timetable_use_case;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TimetableModelTest {
+    private TimetableModel timetable;
+
+    @BeforeEach
+    void setUp() {
+        List<CourseModel> courses = new ArrayList<>();
+        courses.add(new CourseModel("some course", new ArrayList<>(), "F",
+                "CSD203", "BR1"));
+        timetable = new TimetableModel(courses);
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void testEquals() {
+        List<CourseModel> courses = new ArrayList<>();
+        courses.add(new CourseModel("some course", new ArrayList<>(), "F",
+                "CSD203", "BR1"));
+        assertEquals(new TimetableModel(courses), timetable);
+    }
+
+    @Test
+    void testNotEquals() {
+        assertNotEquals(new TimetableModel(new ArrayList<>()), timetable);
+    }
+}

--- a/src/test/java/retrieve_timetable_use_case/TimetableModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/TimetableModelTest.java
@@ -9,6 +9,11 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * A test suite for the TimetableModel class, primarily to confirm the correctness of its equal method.
+ * The setters and getters are currently too simple to require testing, but must be tested if more complex
+ * behaviour is introduced.
+ */
 class TimetableModelTest {
     private TimetableModel timetable;
 
@@ -24,6 +29,9 @@ class TimetableModelTest {
     void tearDown() {
     }
 
+    /**
+     * Tests that the Timetable and its equivalent TimetableModel are considered equal.
+     */
     @Test
     void testEquals() {
         List<CourseModel> courses = new ArrayList<>();
@@ -32,6 +40,9 @@ class TimetableModelTest {
         assertEquals(new TimetableModel(courses), timetable);
     }
 
+    /**
+     * Tests that the Timetable and a non-equivalent TimetableModel are non-equal.
+     */
     @Test
     void testNotEquals() {
         assertNotEquals(new TimetableModel(new ArrayList<>()), timetable);

--- a/src/test/java/retrieve_timetable_use_case/TimetableModelTest.java
+++ b/src/test/java/retrieve_timetable_use_case/TimetableModelTest.java
@@ -3,11 +3,13 @@ package retrieve_timetable_use_case;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import retrieve_timetable_use_case.application_business.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * A test suite for the TimetableModel class, primarily to confirm the correctness of its equal method.

--- a/src/test/java/screens/RemoveCoursePresenterTest.java
+++ b/src/test/java/screens/RemoveCoursePresenterTest.java
@@ -1,13 +1,11 @@
 package screens;
 
-import edit_timetable_use_case.EditTimetableRequestModel;
 import edit_timetable_use_case.EditTimetableResponseModel;
-import edit_timetable_use_case.RemoveCourseOutputBoundary;
 import edit_timetable_use_case.TestEditTimetableView;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import retrieve_timetable_use_case.TimetableModel;
+import retrieve_timetable_use_case.application_business.TimetableModel;
 
 import java.util.ArrayList;
 


### PR DESCRIPTION
Feature branch 9, the retrieve timetable use case, was not fully documented, cleared of IntelliJ warnings, and tested, since it was submitted prematurely for the milestone 3 deadline. The branch has now been cleaned up.

All classes in the retrieve timetable use case and the models now have appropriate documentation and testing. Equals methods between the models and their corresponding entities have also been added for testing purposes, and they themselves also have tests.