### PR TITLE
Updated conditions for Block in constructor and changed to switch statement

### DIFF
--- a/src/main/java/entities/Block.java
+++ b/src/main/java/entities/Block.java
@@ -10,16 +10,26 @@ public class Block {
     private final String room;
 
     public Block(String day, String startTime, String endTime, String room) {
-        if (day.equals("MO")) {
-            this.day = 0;
-        } else if (day.equals("TU")) {
-            this.day = 1;
-        } else if (day.equals("WE")) {
-            this.day = 2;
-        } else if (day.equals("TH")) {
-            this.day = 3;
-        } else {
-            this.day = 4;
+        switch (day) {
+            case "MO":
+            case "0":
+                this.day = 0;
+                break;
+            case "TU":
+            case "1":
+                this.day = 1;
+                break;
+            case "WE":
+            case "2":
+                this.day = 2;
+                break;
+            case "TH":
+            case "3":
+                this.day = 3;
+                break;
+            default:
+                this.day = 4;
+                break;
         }
 
 


### PR DESCRIPTION
In this PR (created to fix bug), the if-then statements was changed to fix a bug where it did not accept days to numeric values, which caused an issue where sections from imported timetables were all set to Friday. Also if-the statement was switched to a switch statement